### PR TITLE
feat: addition of delete functionality end to end

### DIFF
--- a/backend-node/src/routes/vendors.ts
+++ b/backend-node/src/routes/vendors.ts
@@ -87,4 +87,23 @@ router.post('/', (req: Request, res: Response) => {
     });
 });
 
+// DELETE /vendors/:id - Delete a vendor by ID
+// It extracts id from URL params and validates it. If missing, returns 400.
+// It uses a RETURNING clause to get the id of the deleted vendor.
+// If the vendor is not found, it returns 404.
+// If the vendor is found, it deletes the vendor and returns 204.
+// If the vendor is not found, it returns 404.
+// If the vendor is found, it deletes the vendor and returns 204.
+router.delete('/:id', (req: Request, res: Response) => {
+    const { id } = req.params;
+  if (!id) return res.status(400).json({ error: 'Vendor id is required' });
+
+  const sql = 'DELETE FROM vendors WHERE id = ? RETURNING id';
+  db.all(sql, [id], (err, rows: Array<{ id: number }>) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!rows || rows.length === 0) return res.status(404).json({ error: 'Vendor not found' });
+    return res.status(204).send();
+  });
+});
+
 export default router;

--- a/backend-node/src/tests/test-endpoints.ts
+++ b/backend-node/src/tests/test-endpoints.ts
@@ -77,6 +77,30 @@ async function testEndpoints(): Promise<void> {
         const checkNewVendorEmail: AxiosResponse<EmailCheckResponse> = await axios.get(`${BASE_URL}/vendors/check-email/newjohndoe@test.com`);
         console.log('Response:', checkNewVendorEmail.data);
 
+        // Test 6: Delete the newly added vendor by id
+        console.log('\n6. Deleting the newly added vendor...');
+        const newVendorId = (newVendor.data as Vendor).id as number;
+        const deleteResp = await axios.delete(`${BASE_URL}/vendors/${newVendorId}`);
+        console.log('Delete response status:', deleteResp.status);
+
+        // Test 7: Verify deletion (check-email should now be available)
+        console.log('7. Verifying deletion via email check...');
+        const checkAfterDelete: AxiosResponse<EmailCheckResponse> = await axios.get(`${BASE_URL}/vendors/check-email/newjohndoe@test.com`);
+        console.log('Response after delete:', checkAfterDelete.data);
+
+        // Test 8: Deleting again should return 404
+        console.log('8. Deleting again should result in 404...');
+        try {
+            await axios.delete(`${BASE_URL}/vendors/${newVendorId}`);
+            console.log('Unexpected success on second delete');
+        } catch (error) {
+            if (axios.isAxiosError(error) && error.response) {
+                console.log('Expected 404 response:', error.response.status, error.response.data);
+            } else {
+                console.log('Error:', (error as Error).message);
+            }
+        }
+
     } catch (error) {
         console.error('Test failed:', (error as Error).message);
         if (axios.isAxiosError(error)) {

--- a/frontend/src/components/VendorList.vue
+++ b/frontend/src/components/VendorList.vue
@@ -12,6 +12,7 @@
           <th>Contact Person</th>
           <th>Email</th>
           <th>Partner Type</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -21,6 +22,9 @@
           <td>{{ vendor.contact_person }}</td>
           <td>{{ vendor.email }}</td>
           <td>{{ vendor.partner_type }}</td>
+          <td>
+            <button class="delete-btn" @click.stop="onDelete(vendor.id)">Delete</button>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -37,6 +41,19 @@ const vendorStore = useVendorStore();
 onMounted(() => {
   vendorStore.fetchVendors();
 });
+
+/* delete vendor with id
+ add a confirmation dialog
+ if confirmed, delete the vendor
+ if not confirmed, do nothing
+ */
+
+function onDelete(id?: number) {
+  if (!id) return;
+  const confirmed = window.confirm('Are you sure you want to delete this vendor?');
+  if (!confirmed) return;
+  vendorStore.deleteVendor(id);
+}
 </script>
 
 <style scoped>
@@ -75,5 +92,18 @@ onMounted(() => {
   padding: 20px;
   text-align: center;
   color: #666;
+}
+
+.delete-btn {
+  background-color: #e53e3e;
+  color: #fff;
+  border: none;
+  padding: 6px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.delete-btn:hover {
+  background-color: #c53030;
 }
 </style>

--- a/frontend/src/stores/vendorStore.ts
+++ b/frontend/src/stores/vendorStore.ts
@@ -38,6 +38,27 @@ export const useVendorStore = defineStore('vendor', () => {
       loading.value = false
     }
   }
+/*
+  deleteVendor(id: number)
+  call the delete API
+  if successful, update the store’s vendors array locally (filter out the deleted id) instead of refetching the whole list from the server. This keeps the UI snappy and reduces network load.
+  if not successful, show an error message
+ */
+  async function deleteVendor(id: number) {
+    loading.value = true
+    error.value = null
+    
+    try {
+      await VendorService.deleteVendor(String(id))
+      vendors.value = vendors.value.filter(v => v.id !== id)
+    } catch (err) {
+      error.value = 'Failed to delete vendor. Please try again later.'
+      console.error(err)
+      throw err
+    } finally {
+      loading.value = false
+    }
+  }
 
   async function checkEmailAvailability(email: string): Promise<EmailCheckResponse> {
     try {
@@ -54,6 +75,7 @@ export const useVendorStore = defineStore('vendor', () => {
     error,
     fetchVendors,
     addVendor,
+    deleteVendor,
     checkEmailAvailability
   }
 })

--- a/frontend/src/tests/components/VendorForm.spec.ts
+++ b/frontend/src/tests/components/VendorForm.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { nextTick } from 'vue';
 import { mount } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 import VendorForm from '../../components/VendorForm.vue';
@@ -71,6 +72,12 @@ describe('VendorForm', () => {
     });
     
     const store = useVendorStore();
+    // Mock email check to return not existing
+    // @ts-expect-error spy injected by createTestingPinia
+    store.checkEmailAvailability.mockResolvedValue({ exists: false, message: 'ok' });
+    // Ensure addVendor resolves as a promise
+    // @ts-expect-error spy injected by createTestingPinia
+    store.addVendor.mockResolvedValue(undefined);
     
     // Fill out the form
     await wrapper.find('#name').setValue('Test Company');
@@ -80,6 +87,7 @@ describe('VendorForm', () => {
     
     // Submit the form
     await wrapper.find('form').trigger('submit');
+    await nextTick();
     
     // Check that the store's addVendor method was called with correct data
     expect(store.addVendor).toHaveBeenCalledWith({

--- a/frontend/src/tests/components/VendorList.spec.ts
+++ b/frontend/src/tests/components/VendorList.spec.ts
@@ -128,7 +128,7 @@ describe('VendorList', () => {
     
     // Check that the table exists and has correct structure
     expect(wrapper.find('.vendors-table').exists()).toBe(true);
-    expect(wrapper.findAll('th').length).toBe(5);
+    expect(wrapper.findAll('th').length).toBe(6);
     expect(wrapper.findAll('tbody tr').length).toBe(2);
     
     // Check content of first row
@@ -138,5 +138,60 @@ describe('VendorList', () => {
     expect(firstRow.findAll('td')[2].text()).toBe('John Test');
     expect(firstRow.findAll('td')[3].text()).toBe('john@testcompany.com');
     expect(firstRow.findAll('td')[4].text()).toBe('Supplier');
+    expect(firstRow.findAll('td')[5].find('button').text()).toBe('Delete');
+  });
+
+  it('deletes a vendor after confirmation when clicking Delete', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const wrapper = mount(VendorList, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              vendor: { loading: false, vendors: mockVendors, error: null }
+            }
+          })
+        ]
+      }
+    });
+
+    const store = useVendorStore();
+    const deleteSpy = vi.spyOn(store, 'deleteVendor');
+
+    const firstRowDeleteBtn = wrapper.findAll('tbody tr')[0].find('button');
+    await firstRowDeleteBtn.trigger('click');
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(deleteSpy).toHaveBeenCalledWith(1);
+
+    confirmSpy.mockRestore();
+  });
+
+  it('does not delete when confirmation is cancelled', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const wrapper = mount(VendorList, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            initialState: {
+              vendor: { loading: false, vendors: mockVendors, error: null }
+            }
+          })
+        ]
+      }
+    });
+
+    const store = useVendorStore();
+    const deleteSpy = vi.spyOn(store, 'deleteVendor');
+
+    const firstRowDeleteBtn = wrapper.findAll('tbody tr')[0].find('button');
+    await firstRowDeleteBtn.trigger('click');
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
   });
 });

--- a/frontend/src/tests/stores/vendorStore.spec.ts
+++ b/frontend/src/tests/stores/vendorStore.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useVendorStore } from '../../stores/vendorStore';
 import { VendorService } from '../../services/VendorService';
@@ -8,11 +8,13 @@ import type { Vendor } from '../../types/Vendor';
 vi.mock('../../services/VendorService', () => ({
   VendorService: {
     getVendors: vi.fn(),
-    createVendor: vi.fn()
+    createVendor: vi.fn(),
+    deleteVendor: vi.fn()
   }
 }));
 
 describe('VendorStore', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
   const mockVendors: Vendor[] = [
     {
       id: 1,
@@ -36,6 +38,14 @@ describe('VendorStore', () => {
     // Reset mocks
     vi.mocked(VendorService.getVendors).mockReset();
     vi.mocked(VendorService.createVendor).mockReset();
+    vi.mocked(VendorService.deleteVendor).mockReset();
+
+    // Silence expected error logs in tests exercising error paths
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it('has initial state', () => {
@@ -133,6 +143,40 @@ describe('VendorStore', () => {
       } catch (e) {
         expect(store.loading).toBe(false);
         expect(store.error).toBe('Failed to add vendor. Please try again later.');
+      }
+    });
+  });
+
+  describe('deleteVendor', () => {
+    it('calls API and removes vendor from state', async () => {
+      const store = useVendorStore();
+      // seed state
+      store.vendors = [...mockVendors] as unknown as typeof store.vendors;
+      vi.mocked(VendorService.deleteVendor).mockResolvedValue();
+
+      await store.deleteVendor(1);
+
+      expect(VendorService.deleteVendor).toHaveBeenCalledWith('1');
+      expect(store.vendors.length).toBe(1);
+      expect(store.vendors[0].id).toBe(2);
+      expect(store.loading).toBe(false);
+      expect(store.error).toBe(null);
+    });
+
+    it('handles API errors correctly', async () => {
+      const store = useVendorStore();
+      // seed state
+      store.vendors = [...mockVendors] as unknown as typeof store.vendors;
+      const error = new Error('API delete failed');
+      vi.mocked(VendorService.deleteVendor).mockRejectedValue(error);
+
+      try {
+        await store.deleteVendor(1);
+        expect(true).toBe(false);
+      } catch (e) {
+        expect(store.loading).toBe(false);
+        expect(store.error).toBe('Failed to delete vendor. Please try again later.');
+        expect(store.vendors.length).toBe(2);
       }
     });
   });


### PR DESCRIPTION
Description:
- Add end-to-end Vendor Delete functionality (backend + frontend + tests)
- Implemented deletion of a vendor by ID across the stack.
- Added a Delete action in the UI with a confirmation dialog to prevent accidental removals.
- Updated store and tests to cover success and error paths.

**Backend**
- Added DELETE /api/vendors/:id in backend-node/src/routes/vendors.ts.
- Validates id.
- Executes DELETE FROM vendors WHERE id = ?.
- Returns:
- 204 on success
- 404 if vendor not found
- 400 on invalid request
- 500 on DB errors

**Frontend** 

- frontend/src/components/VendorList.vue:
  - Added Actions column with a Delete button per row.
  - Prompts with window.confirm before deletion.
  - Calls store action on confirmation.
- frontend/src/stores/vendorStore.ts:
  - Added deleteVendor(id: number):
  - Calls API and updates local state by filtering the deleted vendor on success.
  - Sets user-friendly error on failure.
  - Maintains loading state.
  
**Tests**
- Backend: Extended endpoint test script backend-node/src/tests/test-endpoints.ts:
- Creates a vendor, deletes it, verifies delete via email check, and asserts 404 on second delete.
- Frontend:
- Store tests frontend/src/tests/stores/vendorStore.spec.ts:
- Added tests for deleteVendor success and error cases.
- Silences expected console.error logs in error-path tests.
- List tests frontend/src/tests/components/VendorList.spec.ts:
- Updated for Actions column and Delete button.
- Added tests for confirm-then-delete and cancel-no-delete.
- Form tests frontend/src/tests/components/VendorForm.spec.ts

**How to Test Manually**

**Backend:**
- Start Node server.
- POST /api/vendors to create a vendor; note the returned id.
- DELETE /api/vendors/:id → expect 204.
- DELETE /api/vendors/:id again → expect 404.

**Frontend:**

- Load Vendor list, click Delete on any row.
- Accept confirmation → row is removed; cancel → no change.
- Error Handling
- Store exposes user-friendly errors on fetch/add/delete failures.
- Confirmation dialog prevents accidental deletes.
- Tests simulate network errors to ensure graceful handling.

**Screenshots:**
<img width="1299" height="648" alt="Screenshot 2025-08-29 at 7 11 45 PM" src="https://github.com/user-attachments/assets/5c4be4e1-dcba-4345-93da-5eb887dd097f" />

<img width="1421" height="737" alt="Screenshot 2025-08-29 at 7 12 01 PM" src="https://github.com/user-attachments/assets/5c2cd7a4-b28e-418f-acd0-03e4f430d76d" />

<img width="1413" height="690" alt="Screenshot 2025-08-29 at 7 12 55 PM" src="https://github.com/user-attachments/assets/83a4ff86-2b2b-44f1-8d3b-42e216a48c00" />



